### PR TITLE
Fixes #2: JPA 쿼리 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
       ddl-auto: none
     properties:
       hibernate:
-        show_sql: true-
+        show_sql: true
         format_sql: true
         default_batch_fetch_size: 40
         # 100으로 하면 limit=20인 쿼리가 12/8로 나뉘어서 나간다. 1~10, 12, 25, 50, 100중 12와 8로 처리하기 때문

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,9 +23,12 @@ spring:
       ddl-auto: none
     properties:
       hibernate:
-        show_sql: true
+        show_sql: true-
         format_sql: true
-        default_batch_fetch_size: 100
+        default_batch_fetch_size: 40
+        # 100으로 하면 limit=20인 쿼리가 12/8로 나뉘어서 나간다. 1~10, 12, 25, 50, 100중 12와 8로 처리하기 때문
+        # https://velog.io/@joonghyun/SpringBoot-JPA-JPA-Batch-Size%EC%97%90-%EB%8C%80%ED%95%9C-%EA%B3%A0%EC%B0%B0
+        # https://www.inflearn.com/community/questions/34469/default-batch-fetch-size-%EA%B4%80%EB%A0%A8%EC%A7%88%EB%AC%B8
   security:
     oauth2:
       client:


### PR DESCRIPTION
조회 갯수를 고려하여 default_batch_fetch_size: 40으로 설정했습니다.
이는 하이버네이트 최적화 문제입니다. in절을 미리 생성하여 캐시하는데 100인 경우 in 갯수 1~10, 12, 25, 50, 100으로 생성하기 때문에 12/8로 처리하는 것입니다.

참조 : https://www.inflearn.com/community/questions/34469/default-batch-fetch-size-%EA%B4%80%EB%A0%A8%EC%A7%88%EB%AC%B8