### PR TITLE
Fix #6: 로그 예외 분류

### DIFF
--- a/src/main/java/guckflix/backend/exception/BusinessException.java
+++ b/src/main/java/guckflix/backend/exception/BusinessException.java
@@ -1,0 +1,4 @@
+package guckflix.backend.exception;
+
+public interface BusinessException {
+}

--- a/src/main/java/guckflix/backend/exception/DuplicateException.java
+++ b/src/main/java/guckflix/backend/exception/DuplicateException.java
@@ -1,6 +1,6 @@
 package guckflix.backend.exception;
 
-public class DuplicateException extends RuntimeException{
+public class DuplicateException extends RuntimeException implements BusinessException{
 
     public DuplicateException() {
     }

--- a/src/main/java/guckflix/backend/exception/NotFoundException.java
+++ b/src/main/java/guckflix/backend/exception/NotFoundException.java
@@ -1,6 +1,6 @@
 package guckflix.backend.exception;
 
-public class NotFoundException extends RuntimeException{
+public class NotFoundException extends RuntimeException implements BusinessException{
         public NotFoundException() {
         }
         public NotFoundException(String message) {

--- a/src/main/java/guckflix/backend/log/LogAspect.java
+++ b/src/main/java/guckflix/backend/log/LogAspect.java
@@ -2,6 +2,7 @@ package guckflix.backend.log;
 
 import com.google.common.collect.Lists;
 import guckflix.backend.entity.Member;
+import guckflix.backend.exception.BusinessException;
 import guckflix.backend.exception.NotFoundException;
 import guckflix.backend.security.authen.PrincipalDetails;
 import lombok.RequiredArgsConstructor;
@@ -60,6 +61,12 @@ public class LogAspect {
     // 익셉션 로깅 AOP
     @AfterThrowing(pointcut = "execution(* guckflix.backend.controller.*.*(..))", throwing = "e")
     public void exceptionLogging(JoinPoint joinPoint, Exception e) {
+
+        // 예외 분류. 사용자 오입력, ID 중복같은 비즈니스 익셉션이면 로그를 남기지 않음
+        // 그 이외 모든 예외 로깅
+        if(e instanceof BusinessException) {
+            return;
+        }
 
         // 사용자 정보
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();


### PR DESCRIPTION
DuplicateException, NotFoundException같이 비즈니스 로직 예외 처리를 위해 마커 인터페이스인 BusinessException을 생성했습니다. 비즈니스 예외인 경우는 사용자 실수인 경우가 많으므로 로깅하지 않고, 비즈니스 예외가 아닌 모든 예외를 로깅하도록 변경했습니다