### PR TITLE
Feat: 예외 발생 시 Slack 알람 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 	// AOP
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 
+	// 특정 예외 발생 시 slack 알람 기능
+	implementation 'com.slack.api:slack-api-client:1.30.0'
+
 	// API 문서를 위한 스웨거
 	implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
 	implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'

--- a/src/main/java/guckflix/backend/log/MDCFilter.java
+++ b/src/main/java/guckflix/backend/log/MDCFilter.java
@@ -1,0 +1,17 @@
+package guckflix.backend.log;
+
+import org.slf4j.MDC;
+
+import javax.servlet.*;
+import java.io.IOException;
+import java.util.UUID;
+
+public class MDCFilter implements Filter {
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        final UUID uuid = UUID.randomUUID();
+        MDC.put("request_id", uuid.toString());
+        filterChain.doFilter(servletRequest, servletResponse);
+        MDC.clear();
+    }
+}

--- a/src/main/java/guckflix/backend/log/SlackAlarm.java
+++ b/src/main/java/guckflix/backend/log/SlackAlarm.java
@@ -1,0 +1,71 @@
+package guckflix.backend.log;
+
+import com.slack.api.Slack;
+import com.slack.api.model.Attachment;
+import com.slack.api.model.Field;
+import com.slack.api.webhook.Payload;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class SlackAlarm {
+
+    @Value("${slack.webhook.url}")
+    private String url;
+    private final Slack slackClient = Slack.getInstance();
+
+    /**
+     * 2024-10-21T22:09:23.027650100 에 발생한 에러 로그
+     * 로그 UUID
+     * b5e4cacc-b7b3-446e-b719-ea30be6d5da7
+     * 요청
+     * GET http://localhost:8081/test
+     * 예외가 발생한 클래스
+     * String guckflix.backend.controller.TestController.test()
+     * 예외 클래스
+     * class guckflix.backend.exception.NotAllowedIdException
+     */
+    public void sendAlert(String uuid, String requestURL, String occuredClass, Exception e) {
+
+        try {
+
+            Attachment attachment = generateSlackAttachment(uuid, requestURL, occuredClass, e);
+
+            Payload payload = Payload.builder().username("예외 감지기")
+                    .text("예외가 감지되었습니다. 확인이 필요합니다.")
+                    .attachments(List.of(attachment))
+                    .build();
+
+            slackClient.send(url, payload);
+        } catch (IOException ie) {
+            throw new RuntimeException(ie);
+        }
+    }
+
+    private Attachment generateSlackAttachment(String uuid, String requestURL, String occuredClass, Exception e) {
+
+        return Attachment.builder()
+                .color("ff0000")
+                .title(LocalDateTime.now() + " 에 발생한 에러 로그")
+                .fields(List.of(
+                        generateSlackField("로그 UUID", uuid),
+                        generateSlackField("요청", requestURL),
+                        generateSlackField("예외가 발생한 클래스", occuredClass),
+                        generateSlackField("예외 클래스", e.getClass().toString())
+                )).build();
+    }
+
+    private Field generateSlackField(String title, String value) {
+        return Field.builder()
+                .title(title)
+                .value(value)
+                .build();
+
+    }
+
+}

--- a/src/main/java/guckflix/backend/security/SecurityConfig.java
+++ b/src/main/java/guckflix/backend/security/SecurityConfig.java
@@ -1,8 +1,10 @@
 package guckflix.backend.security;
 
+import guckflix.backend.log.MDCFilter;
 import guckflix.backend.security.authen.PrincipalOauth2UserService;
 import guckflix.backend.security.handlers.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -119,6 +121,15 @@ public class SecurityConfig {
         config.addExposedHeader("location");
         source.registerCorsConfiguration("/**", config); // 전체에 cors 필터 설정
         return new CorsFilter(source);
+    }
+
+    @Bean
+    public FilterRegistrationBean<MDCFilter> mdcFilter() {
+        FilterRegistrationBean<MDCFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new MDCFilter());
+        registrationBean.addUrlPatterns("/*");
+        registrationBean.setOrder(1);
+        return registrationBean;
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,3 +51,6 @@ logging.level:
   org.springframework.data.redis: DEBUG
   # org.hibernate.SQL: info
   org.hibernate.type.descriptor.sql.BasicBinder: trace
+slack:
+  webhook:
+    url: ${SLACK_WEBHOOK_URL}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -6,7 +6,7 @@
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <!-- encoder 패턴 : 로그 출력 형태를 설정. 콘솔은 가독성을 위해 %green() 처럼 색상을 입힘 -->
         <encoder>
-            <pattern>%green(%d{yyyy-MM-dd HH:mm:ss.SSS}) %magenta([%thread]) %highlight(%5level) %cyan(%logger) - %msg%n</pattern>
+            <pattern>%green(%d{yyyy-MM-dd HH:mm:ss.SSS}) %magenta([%thread]) %highlight(%5level) [%X{request_id}] %cyan(%logger) - %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
merge 하기 이전(github action 동작 이전) 운영 환경에 환경 변수 SLACK_WEBHOOK_URL 설정 필요 로그가 섞이는 것을 막기 위해 MDC를 생성하는 필터를 등록했습니다.
비즈니스익셉션 외의 예외 발생 시 LogAspect에서 로깅한 뒤 SlackAlarm을 호출하여 알람을 보냅니다. 알람에는 시간, 로그 UUID, 요청 URL + 메서드, 예외 발생한 클래스, 예외 클래스 정보가 담깁니다. 알람은 슬랙 alert 채널에 작성됩니다.